### PR TITLE
improved handling of inbound requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,66 @@
 {
   "name": "@warren-bank/hls-proxy",
-  "version": "0.16.1",
+  "version": "0.18.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@warren-bank/node-denodeify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@warren-bank/node-denodeify/-/node-denodeify-1.3.1.tgz",
-      "integrity": "sha512-kdC9zHY3iGVX6uKOcX2GJG/OUZNeRjKKECVGbTaq1v3s2bn0EIEbcr2ObGL34+Sy/kuonj3dhfzmmlb2WbzqoQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@warren-bank/node-denodeify/-/node-denodeify-2.0.1.tgz",
+      "integrity": "sha512-B23FyB0npH1/FngxQ2byf23fGgscRr/76F70z+G2yEUlfuv832X4aWSVT0+s0DkF86q86X5FmG/QqAJhZE9b5A=="
     },
     "@warren-bank/node-request": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@warren-bank/node-request/-/node-request-1.0.4.tgz",
-      "integrity": "sha1-KPDqhbjWAlOJPSgk83MAeSD1Ulw=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@warren-bank/node-request/-/node-request-2.0.1.tgz",
+      "integrity": "sha512-5KwehLWCGDrqN3aRnIr4byQ7weiYgsWAkRpnRo+4zd6ZORfqHgfCSyP0m5/TdzB3/vdWPWca5nIrLag/uOd71g==",
       "requires": {
-        "@warren-bank/node-denodeify": "^1.2.2"
+        "@warren-bank/node-denodeify": "^2.0.1",
+        "tough-cookie": "^3.0.1",
+        "tough-cookie-filestore2": "^1.0.0"
+      }
+    },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "tough-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+      "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+      "requires": {
+        "ip-regex": "^2.1.0",
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "tough-cookie-filestore2": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie-filestore2/-/tough-cookie-filestore2-1.0.0.tgz",
+      "integrity": "sha512-2/p7yiS7CBura7JzfCO72iuWNRbB2ot/Hz4VtiP6qcrgvYXUbeiyEUf6fz8i9gWvzOad83gOUCtg5PtLpErZug==",
+      "requires": {
+        "tough-cookie": "^2.3.3"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@warren-bank/hls-proxy",
   "description": "Node.js server to proxy HLS video streams",
-  "version":     "0.18.2",
+  "version":     "0.18.3",
   "scripts": {
     "start":     "node hls-proxy/bin/hlsd.js",
     "sudo": "sudo node hls-proxy/bin/hlsd.js"
@@ -10,7 +10,7 @@
     "hlsd": "hls-proxy/bin/hlsd.js"
   },
   "dependencies": {
-    "@warren-bank/node-request": "^1.0.4"
+    "@warren-bank/node-request": "^2.0.1"
   },
   "license": "GPL-2.0",
   "author": {


### PR DESCRIPTION
* ignore requests that:
  - don't include a pathname
  - include a pathname that isn't properly encoded
  - include a properly encoded pathname that doesn't contain a URL

* normalize the URL contained by a properly encoded pathname
  - this is mainly intended to handle the situation:
    * HLS manifest uses a relative path to a parent directory
      - example:
        * master manifest:
          - url:
              http://hostname/path/to/master.m3u8
          - contains relative url:
              ../../720p.m3u8
        * child manifest:
          - url (not normalized):
              http://hostname/path/to/../../720p.m3u8
            server response:
              400 (Bad Request)
          - url (normalized):
              http://hostname/720p.m3u8
            server response:
              200 (OK)

notes:
======

* rather than normalizing relative URLs while performing in-flight updates to manifests,
  I opted for a more general-purpose approach

* URL normalization was added to the upstream library dependency: "node-request",
  which corresponds to bumping the version of this dependency to v2.0.1 (or higher)